### PR TITLE
Change to OS version regex to fix for GCE

### DIFF
--- a/catalog/sawtooth/common.bom
+++ b/catalog/sawtooth/common.bom
@@ -47,7 +47,8 @@ brooklyn.catalog:
         brooklyn.config:
           dontRequireTtyForSudo: true
           provisioning.properties.osFamily: ubuntu
-          provisioning.properties.imageNameRegex: "xenial-16.04"
+          provisioning.properties.osVersionRegex: 16.?04.*
+
 
     - id: sawtooth-docker-engine
       description: |

--- a/docs/advanced-installation.md
+++ b/docs/advanced-installation.md
@@ -19,6 +19,7 @@ You should now see `sawtooth-platform` in the "Create Application" of the Brookl
 
 Now you can follow along with the getting started guide from [here](./getting-started.md#configure-and-add-an-aws-deployment-location), assuming you have already completed the prerequisite AWS account setup described [here](./aws-setup.md).
 
+There are also instructions [here] (./gce-setup.md) for using GCE as a target cloud.
 
 ---
 Copyright 2018 Blockchain Technology Partners Limited; Licensed under the [Apache License, Version 2.0](../LICENSE)

--- a/docs/gce-setup.md
+++ b/docs/gce-setup.md
@@ -1,0 +1,30 @@
+GCE Account Setup
+=================
+
+This document provides instructions for setting up your GCE account onto which you will deploy the Sawtooth platform.  For more information on configuring GCE as a target cloud see the Apache Brooklyn docs [here](https://brooklyn.apache.org/v/latest/locations/index.html#google-compute-engine-gce)
+
+### Create a GCE Service Account
+
+Follow [this guide](https://cloud.google.com/iam/docs/service-accounts) to create a service account.  You will need to download the private key and you will also need the email address that google has assigned to the service account.
+
+You will need to create a location that looks like the following:
+
+```
+location:
+  jclouds:google-compute-engine:
+    region: us-central1-a
+    identity: <email of service account>
+    credential: |
+      <private key for service account>
+    templateOptions:
+      network: <VPC url setup as discussed below>
+```
+
+### Setup GCE firewall rules
+
+It is recommended that you setup a VPC with default subnets for any region that you wish to deploy the hyperledger-broolkyn-sawtooth blueprint to.
+
+Follow [this guide](https://cloud.google.com/appengine/docs/standard/python/creating-firewalls) to setup 2 default firewall rules for the target region(s).  The first rule should allow all traffice within the target subnet and the second should allow the following inbound access from your IP (or 0.0.0.0/0 for all access): 22, 3000, 3030, 4200, 4201, 8000, 8080, 8090, 9090.
+
+---
+Copyright 2018 Blockchain Technology Partners Limited; Licensed under the [Apache License, Version 2.0](../LICENSE)


### PR DESCRIPTION
Minor change to use version regex so that jclouds will pick a suitable
image on both AWS and GCE.

Docs to help people get started on GCE.